### PR TITLE
Allow nil option in validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,6 +773,54 @@ Validations are run when calling `valid?` or when calling any API on an instance
 
 `full_error_messages` returns an array of attributes with their associated error messages, i.e. `["age must be at least 18"]`
 
+#### Permitting nil values
+The default behavior for `:length`, `:numericality` and `:inclusion` validators is to fail when a `nil` value is encountered. You can prevent `nil` attribute values from triggering validation errors for attributes that may permit `nil` by adding the `:allow_nil => true` option. Adding this option with a `true` value to `:length`, `:numericality` and `:inclusion` validators will permit `nil` values and not trigger errors. Some examples are:
+
+```ruby
+class Person < Flexirest::Base
+  validates :first_name, presence: true
+  validates :middle_name, length: { minimum: 2, maximum: 30 }, allow_nil: true
+  validates :last_name, existence: true
+  validates :nick_name, length: { minimum: 2, maximum: 30 }
+  validates :alias, length: { minimum: 2, maximum: 30 }, allow_nil: false
+  validates :password, length: { within: 6..12 }
+  validates :post_code, length: { minimum: 6, maximum: 8 }
+  validates :salary, numericality: true, minimum: 20_000, maximum: 50_000
+  validates :age, numericality: { minimum: 18, maximum: 65 }
+  validates :suffix, inclusion: { in: %w{Dr. Mr. Mrs. Ms.}}
+  validates :golf_score, numericality: true, allow_nil: true
+  validates :retirement_age, numericality: { minimum: 65 }, allow_nil: true
+  validates :cars_owned, numericality: true
+  validates :houses_owned, numericality: true, allow_nil: false
+  validates :favorite_authors, inclusion: { in: ["George S. Klason", "Robert T. Kiyosaki", "Lee Child"] }, allow_nil: true
+  validates :favorite_artists, inclusion: { in: ["Claude Monet", "Vincent Van Gogh", "Andy Warhol"] }
+  validates :favorite_composers, inclusion: { in: ["Mozart", "Bach", "Pachelbel", "Beethoven"] }, allow_nil: false
+end
+```
+
+In the example above, the following results would occur when calling `valid?` on an instance where all attributes have `nil` values:
+
+- `:first_name` must be present
+- `:last_name` must be not be nil
+- `:nick_name` must be not be nil
+- `:alias` must not be nil
+- `:password` must not be nil
+- `:post_code` must not be nil
+- `:salary` must not be nil
+- `:age` must not be nil
+- `:suffix` must not be nil
+- `:cars_owned` must not be nil
+- `:houses_owned` must not be nil
+- `:favorite_artists` must not be nil
+- `:favorite_composers` must not be nil
+
+The following attributes will pass validation since they explicitly `allow_nil`:
+
+- `:middle_name`
+- `:golf_score`
+- `:retirement_age`
+- `:favorite_authors`
+
 ### Debugging
 
 You can turn on verbose debugging to see what is sent to the API server and what is returned in one of these two ways:

--- a/lib/flexirest/validation.rb
+++ b/lib/flexirest/validation.rb
@@ -20,6 +20,7 @@ module Flexirest
       @errors = Hash.new {|h,k| h[k] = []}
       self.class._validations.each do |validation|
         value = self.send(validation[:field_name])
+        allow_nil = validation[:options].fetch(:allow_nil, false)
         validation[:options].each do |type, options|
           if type == :presence
             if value.nil?
@@ -32,35 +33,55 @@ module Flexirest
               @errors[validation[:field_name]] << "must be not be nil"
             end
           elsif type == :length
-            if options[:within]
-              @errors[validation[:field_name]] << "must be within range #{options[:within]}" unless options[:within].include?(value.to_s.length )
-            end
-            if options[:minimum]
-              @errors[validation[:field_name]] << "must be at least #{options[:minimum]} characters long" unless value.to_s.length >= options[:minimum]
-            end
-            if options[:maximum]
-              @errors[validation[:field_name]] << "must be no more than #{options[:maximum]} characters long" unless value.to_s.length <= options[:maximum]
+            if value.nil?
+              @errors[validation[:field_name]] << "must be not be nil" unless allow_nil
+            else
+              if options[:within]
+                @errors[validation[:field_name]] << "must be within range #{options[:within]}" unless options[:within].include?(value.to_s.length )
+              end
+              if options[:minimum]
+                @errors[validation[:field_name]] << "must be at least #{options[:minimum]} characters long" unless value.to_s.length >= options[:minimum]
+              end
+              if options[:maximum]
+                @errors[validation[:field_name]] << "must be no more than #{options[:maximum]} characters long" unless value.to_s.length <= options[:maximum]
+              end
             end
           elsif type == :numericality
-            numeric = (true if Float(value) rescue false)
-            if !numeric
-              @errors[validation[:field_name]] << "must be numeric"
+            if value.nil?
+              @errors[validation[:field_name]] << "must be not be nil" unless allow_nil
             else
-              if options.is_a?(Hash)
-                if options[:minimum]
-                  @errors[validation[:field_name]] << "must be at least #{options[:minimum]}" unless value.to_f >= options[:minimum]
-                end
-                if options[:maximum]
-                  @errors[validation[:field_name]] << "must be no more than #{options[:maximum]}" unless value.to_f <= options[:maximum]
+              numeric = (true if Float(value) rescue false)
+              if !numeric
+                @errors[validation[:field_name]] << "must be numeric"
+              else
+                if options.is_a?(Hash)
+                  if options[:minimum]
+                    @errors[validation[:field_name]] << "must be at least #{options[:minimum]}" unless value.to_f >= options[:minimum]
+                  end
+                  if options[:maximum]
+                    @errors[validation[:field_name]] << "must be no more than #{options[:maximum]}" unless value.to_f <= options[:maximum]
+                  end
                 end
               end
             end
-          elsif type == :minimum && !value.nil?
-            @errors[validation[:field_name]] << "must be at least #{options}" unless value.to_f >= options.to_f
-          elsif type == :maximum && !value.nil?
-            @errors[validation[:field_name]] << "must be no more than #{options}" unless value.to_f <= options.to_f
+          elsif type == :minimum
+            if value.nil?
+              @errors[validation[:field_name]] << "must be not be nil" unless allow_nil
+            else
+              @errors[validation[:field_name]] << "must be at least #{options}" unless value.to_f >= options.to_f
+            end
+          elsif type == :maximum
+            if value.nil?
+              @errors[validation[:field_name]] << "must be not be nil" unless allow_nil
+            else
+              @errors[validation[:field_name]] << "must be no more than #{options}" unless value.to_f <= options.to_f
+            end
           elsif type == :inclusion
-            @errors[validation[:field_name]] << "must be included in #{options[:in].join(", ")}" unless options[:in].include?(value)
+            if value.nil?
+              @errors[validation[:field_name]] << "must be not be nil" unless allow_nil
+            else
+              @errors[validation[:field_name]] << "must be included in #{options[:in].join(", ")}" unless options[:in].include?(value)
+            end
           end
         end
         if validation[:block]

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -4,20 +4,29 @@ describe "Flexirest::Validation" do
   class SimpleValidationExample < OpenStruct
     include Flexirest::Validation
     validates :first_name, presence: true
+    validates :middle_name, length: { minimum: 2, maximum: 30 }, allow_nil: true
     validates :last_name, existence: true
+    validates :nick_name, length: { minimum: 2, maximum: 30 }
+    validates :alias, length: { minimum: 2, maximum: 30 }, allow_nil: false
     validates :password, length: { within: 6..12 }
     validates :post_code, length: { minimum: 6, maximum: 8 }
     validates :salary, numericality: true, minimum: 20_000, maximum: 50_000
     validates :age, numericality: { minimum: 18, maximum: 65 }
     validates :suffix, inclusion: { in: %w{Dr. Mr. Mrs. Ms.}}
+    validates :golf_score, numericality: true, allow_nil: true
+    validates :retirement_age, numericality: { minimum: 65 }, allow_nil: true
+    validates :cars_owned, numericality: true
+    validates :houses_owned, numericality: true, allow_nil: false
+    validates :favorite_authors, inclusion: { in: ["George S. Klason", "Robert T. Kiyosaki", "Lee Child"] }, allow_nil: true
+    validates :favorite_artists, inclusion: { in: ["Claude Monet", "Vincent Van Gogh", "Andy Warhol"] }
+    validates :favorite_composers, inclusion: { in: ["Mozart", "Bach", "Pachelbel", "Beethoven"] }, allow_nil: false
   end
 
   it "should be able to register a validation" do
-    expect(SimpleValidationExample._validations.size).to eq(7)
+    expect(SimpleValidationExample._validations.size).to eq(17)
   end
 
   context "when validating presence" do
-
     it "should be invalid if a required value isn't present" do
       a = SimpleValidationExample.new
       a.first_name = nil
@@ -107,6 +116,24 @@ describe "Flexirest::Validation" do
       a.valid?
       expect(a._errors[:post_code].size).to eq(1)
     end
+    
+    it "should be valid if a length is nil and allow_nil option is true" do
+      a = SimpleValidationExample.new
+      a.valid?
+      expect(a._errors[:middle_name]).to be_empty
+    end
+
+    it "should be invalid if a length is nil and allow_nil option is not provided" do
+      a = SimpleValidationExample.new
+      a.valid?
+      expect(a._errors[:nick_name].size).to eq(1)
+    end
+
+    it "should be invalid if a length is nil and allow_nil option is false" do
+      a = SimpleValidationExample.new
+      a.valid?
+      expect(a._errors[:alias].size).to eq(1)
+    end
   end
 
 
@@ -136,6 +163,29 @@ describe "Flexirest::Validation" do
         expect(a._errors[:salary].size).to eq(0)
       end 
 
+      it "should be valid if a value is nil and allow_nil option is true" do
+        a = SimpleValidationExample.new
+        a.valid?
+        expect(a._errors[:golf_score]).to be_empty
+      end
+
+      it "should be valid if a value is nil and allow_nil option is true and a hash of options is passed to numericality" do
+        a = SimpleValidationExample.new
+        a.valid?
+        expect(a._errors[:retirement_age]).to be_empty
+      end
+
+      it "should be invalid if a value is nil and allow_nil option is not provided" do
+        a = SimpleValidationExample.new
+        a.valid?
+        expect(a._errors[:cars_owned].size).to eq(1)
+      end
+
+      it "should be invalid if a value is nil and allow_nil option is false" do
+        a = SimpleValidationExample.new
+        a.valid?
+        expect(a._errors[:houses_owned].size).to eq(1)
+      end
     end
 
     context "using the original format with min and max as types" do
@@ -162,7 +212,6 @@ describe "Flexirest::Validation" do
         a.valid?
         expect(a._errors[:age].size).to eq(0)
       end 
-
     end
   end
 
@@ -177,6 +226,24 @@ describe "Flexirest::Validation" do
       a = SimpleValidationExample.new(suffix: "Dr.")
       a.valid?
       expect(a._errors[:suffix].size).to eq(0)       
+    end
+    
+    it "should be valid if the value is nil and allow_nil option is true" do
+      a = SimpleValidationExample.new
+      a.valid?
+      expect(a._errors[:favorite_authors]).to be_empty
+    end
+
+    it "should be invalid if the value is nil and allow_nil option is not provided" do
+      a = SimpleValidationExample.new
+      a.valid?
+      expect(a._errors[:favorite_artists].size).to eq(1)
+    end
+
+    it "should be invalid if the value is nil and allow_nil option is false" do
+      a = SimpleValidationExample.new
+      a.valid?
+      expect(a._errors[:favorite_composers].size).to eq(1)
     end
   end
 


### PR DESCRIPTION
I found I was writing custom validation blocks to allow nil for certain attributes, so I added an `:allow_nil` option that accepts a boolean value for `:length`, `:numericality` and `:inclusion` validators. I have added tests and a sub-section entitled "Permitting nil values" with examples in the Validation section of the README.

I also found adding this option has resulted in a nil guard where it didn't exist but perhaps should have.

Please let me know if anything can be improved, or if I've missed anything.