### PR TITLE
Array feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,34 @@ puts @person.expenses.reduce {|e| e.inc_vat}
 puts @person.address.full_string
 ```
 
+Sometimes we want attributes to just return a simple Ruby Array. To achieve this we can add an `:array` option to the method. This is especially useful when the attribute contains an array of scalar values. If you don't specify the `:array` option Flexirest will return a `Flexirest::ResultIterator`. To illustrate the difference consider the following example:
+
+```ruby
+class Book < Flexirest::Base
+  # :authors attribute ["Robert T. Kiyosaki", "Sharon L. Lechter C.P.A"]
+  # :genres attribute ["self-help", "finance", "education"]
+  get :find, "/books/:name", array: [:authors]
+end
+```
+
+In the example above, the following results can be observed:
+
+```ruby
+@book = Book.find("rich-dad-poor-dad")
+puts @book.authors
+#=> ["Robert T. Kiyosaki", "Sharon L. Lechter C.P.A"]
+puts @book.authors.class
+#=> Array
+puts @book.genres
+#=> #<Flexirest::ResultIterator:0x007ff420fe7a88 @_status=nil, @_headers=nil, @items=["self-help", "finance", "education"]>
+puts @books.genres.class
+#=> Flexirest::ResultIterator
+puts @books.genres.items
+#=> ["self-help", "finance", "education"]
+```
+
+When the `:array` option includes an attribute, it is assumed the values were returned with the request, and they will not be lazily loaded. It is also assumed the attribute values do not map to a Flexirest resource.
+
 #### Association Type 2 - Lazy Loading From Other URLs
 
 When mapping the method, passing a list of attributes will cause any requests for those attributes to mapped to the URLs given in their responses.  The response for the attribute may be one of the following:

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -13,8 +13,9 @@ module Flexirest
       @method                     = method
       @method[:options]           ||= {}
       @method[:options][:lazy]    ||= []
+      @method[:options][:array]   ||= []
       @method[:options][:has_one] ||= {}
-      @overridden_name             = @method[:options][:overridden_name]
+      @overridden_name            = @method[:options][:overridden_name]
       @object                     = object
       @response_delegate          = Flexirest::RequestDelegator.new(nil)
       @params                     = params
@@ -440,7 +441,11 @@ module Flexirest
         elsif v.is_a? Hash
           object._attributes[k] = new_object(v, overridden_name )
         elsif v.is_a? Array
-          object._attributes[k] = Flexirest::ResultIterator.new
+          if @method[:options][:array].include?(k)
+            object._attributes[k] = Array.new
+          else
+            object._attributes[k] = Flexirest::ResultIterator.new
+          end
           v.each do |item|
             if item.is_a? Hash
               object._attributes[k] << new_object(item, overridden_name)
@@ -514,7 +519,7 @@ module Flexirest
       if @method[:options][:has_many][name] || @method[:options][:has_one][name]
         return name
       end
-
+      
       parent_name || name
     end
 

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -22,6 +22,7 @@ describe Flexirest::Request do
       end
 
       get :all, "/", :has_many => {:expenses => ExampleOtherClient}
+      get :array, "/johnny", array: [:likes, :dislikes]
       get :babies, "/babies", :has_many => {:children => ExampleOtherClient}
       get :single_association, "/single", :has_one => {:single => ExampleSingleClient}, :has_many => {:children => ExampleOtherClient}
       get :headers, "/headers"
@@ -260,6 +261,21 @@ describe Flexirest::Request do
     expect(object.first.first_name).to eq("Johnny")
     expect(object[1].first_name).to eq("Billy")
     expect(object._status).to eq(200)
+  end
+  
+  it "should parse an attribute to be an array if attribute included in array option" do
+    expect_any_instance_of(Flexirest::Connection).to receive(:get).with("/johnny", an_instance_of(Hash)).and_return(::FaradayResponseMock.new(OpenStruct.new(body:"{\"first_name\":\"Johnny\", \"likes\":[\"donuts\", \"bacon\"], \"dislikes\":[\"politicians\", \"lawyers\", \"taxes\"]}", status:200, response_headers:{})))
+    object = ExampleClient.array
+    expect(object.likes).to be_instance_of(Array)
+    expect(object.likes.size).to eq(2)
+    expect(object.likes[0]).to eq("donuts")
+    expect(object.likes[1]).to eq("bacon")
+    expect(object.dislikes).to be_instance_of(Array)
+    expect(object.dislikes.size).to eq(3)
+    expect(object.dislikes[0]).to eq("politicians")
+    expect(object.dislikes[1]).to eq("lawyers")
+    expect(object.dislikes[2]).to eq("taxes")
+    #TODO
   end
 
   it "should instantiate other classes using has_many when required to do so" do


### PR DESCRIPTION
I found that receiving a `Flexirest::ResultIterator` object for an attribute instead of a simple `Array` of scalar values was unexpected and undesired. I found it unexpected because the attribute was not a resource, and had no mapping to a `Flexirest::Base` descendant. The `Flexirest::ResultIterator` added no value in wrapping the array as the attribute could not be lazily loaded, in fact it obscured the attribute by embedding the array in an `#items` attribute.

I have added an `:array` option that accepts an array of attributes that should be treated as `Array`. This feature is backwards compatible, because normal processing occurs when not specifying the attribute.

I have added tests and a section in the README. Please let me know if anything can be improved, or if I've missed anything when you consider this request. 