### PR TITLE
Allow a custom name to be set to be used in logging

### DIFF
--- a/lib/flexirest.rb
+++ b/lib/flexirest.rb
@@ -22,5 +22,12 @@ require "flexirest/base"
 require "flexirest/monkey_patching"
 
 module Flexirest
-  NAME = "Flexirest"
+  @@name = "Flexirest"
+
+  def self.name
+    @@name
+  end
+  def self.name=(value)
+    @@name = value
+  end
 end

--- a/lib/flexirest/caching.rb
+++ b/lib/flexirest/caching.rb
@@ -46,7 +46,7 @@ module Flexirest
       def read_cached_response(request)
         if cache_store && perform_caching
           key = "#{request.class_name}:#{request.original_url}"
-          Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{key} - Trying to read from cache"
+          Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{key} - Trying to read from cache"
           value = cache_store.read(key)
           value = Marshal.load(value) rescue value
         end
@@ -64,7 +64,7 @@ module Flexirest
 
         if cache_store && (headers[:etag] || headers[:expires])
           key = "#{request.class_name}:#{request.original_url}"
-          Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{key} - Writing to cache"
+          Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{key} - Writing to cache"
           cached_response = CachedResponse.new(status:response.status, result:result)
           cached_response.etag = headers[:etag] if headers[:etag]
           cached_response.expires = Time.parse(headers[:expires]) rescue nil if headers[:expires]

--- a/lib/flexirest/instrumentation.rb
+++ b/lib/flexirest/instrumentation.rb
@@ -3,7 +3,7 @@ module Flexirest
     def request_call(event)
       self.class.time_spent += event.duration
       self.class.calls_made += 1
-      name = '%s (%.1fms)' % [Flexirest::NAME, event.duration]
+      name = '%s (%.1fms)' % [Flexirest.name, event.duration]
       Flexirest::Logger.debug "  \033[1;4;32m#{name}\033[0m #{event.payload[:name]}"
     end
 
@@ -47,7 +47,7 @@ module Flexirest
     module ClassMethods
       def log_process_action(payload)
         messages, time_spent, calls_made = super, payload[:flexirest_time_spent], payload[:flexirest_calls_made]
-        messages << ("#{Flexirest::NAME}: %.1fms for %d calls" % [time_spent.to_f, calls_made]) if calls_made
+        messages << ("#{Flexirest.name}: %.1fms for %d calls" % [time_spent.to_f, calls_made]) if calls_made
         Flexirest::Instrumentation.reset
         messages
       end

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -143,7 +143,7 @@ module Flexirest
           if fake.respond_to?(:call)
             fake = fake.call(self)
           end
-          Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name} - Faked response found"
+          Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Faked response found"
           content_type = @method[:options][:fake_content_type] || "application/json"
           return handle_response(OpenStruct.new(status:200, body:fake, response_headers:{"X-ARC-Faked-Response" => "true", "Content-Type" => content_type}))
         end
@@ -158,10 +158,10 @@ module Flexirest
         cached = original_object_class.read_cached_response(self)
         if cached && !cached.is_a?(String)
           if cached.expires && cached.expires > Time.now
-            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name} - Absolutely cached copy found"
+            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Absolutely cached copy found"
             return handle_cached_response(cached)
           elsif cached.etag.to_s != "" #present? isn't working for some reason
-            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name} - Etag cached copy found with etag #{cached.etag}"
+            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Etag cached copy found with etag #{cached.etag}"
             etag = cached.etag
           end
         end
@@ -317,7 +317,7 @@ module Flexirest
         base_url.gsub!(%r{//(.)}, "//#{username}:#{password}@\\1") if username && !base_url[%r{//[^/]*:[^/]*@}]
         connection = Flexirest::ConnectionManager.get_connection(base_url)
       end
-      Flexirest::Logger.info "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name} - Requesting #{connection.base_url}#{@url}"
+      Flexirest::Logger.info "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Requesting #{connection.base_url}#{@url}"
 
       if verbose?
         Flexirest::Logger.debug "Flexirest Verbose Log:"
@@ -376,7 +376,7 @@ module Flexirest
       status = @response.status || 200
 
       if cached && response.status == 304
-        Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name}" +
+        Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name}" +
           ' - Etag copy is the same as the server'
         return handle_cached_response(cached)
       end
@@ -386,9 +386,9 @@ module Flexirest
           return @response = response.body
         elsif is_json_response? || is_xml_response?
           if @response.respond_to?(:proxied) && @response.proxied
-            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name} - Response was proxied, unable to determine size"
+            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Response was proxied, unable to determine size"
           else
-            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest::NAME}\033[0m #{@instrumentation_name} - Response received #{@response.body.size} bytes"
+            Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Response received #{@response.body.size} bytes"
           end
           result = generate_new_object(ignore_xml_root: @method[:options][:ignore_xml_root])
         else

--- a/spec/lib/flexirest_spec.rb
+++ b/spec/lib/flexirest_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Flexirest do
+
+  after(:each) do
+    # Reload Module after each test to ensure name variable is reset to default
+    load 'flexirest.rb'
+  end
+
+  it "should be named Flexirest" do
+    expect(Flexirest.name).to eq('Flexirest')
+  end
+
+  it "should allow setting to something else" do
+    Flexirest.name = 'SomethingElse'
+    expect(Flexirest.name).to eq('SomethingElse')
+  end
+
+end


### PR DESCRIPTION
Refactored the NAME constant on the Flexirest module to be a module variable with a setter and getter.

Added a test to check this.