### PR TITLE
add data to body of connection delete

### DIFF
--- a/lib/flexirest/connection.rb
+++ b/lib/flexirest/connection.rb
@@ -69,12 +69,13 @@ module Flexirest
       end
     end
 
-    def delete(path, options={})
+    def delete(path, data, options={})
       set_defaults(options)
       make_safe_request(path) do
         @session.delete(path) do |req|
           set_per_request_timeout(req, options) if options[:timeout]
           req.headers = req.headers.merge(options[:headers])
+          req.body = data
           sign_request(req, options[:api_auth])
         end
       end

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -340,7 +340,7 @@ module Flexirest
       when :post
         response = connection.post(@url, @body, request_options)
       when :delete
-        response = connection.delete(@url, request_options)
+        response = connection.delete(@url, @body, request_options)
       else
         raise InvalidRequestException.new("Invalid method #{http_method}")
       end


### PR DESCRIPTION
I have a case where I wrap all requests in a user's unique token. All other types of requests besides `DELETE` pass this token to the API side. The API side check fails on `DELETE` because the `connection.delete()` method does not include `@body` as an argument. I understand that `DELETE` typically only receives one parameter anyways, but I wanted to see if there was a specific reason why `@body` is not included on `DELETE` requests for cases like these.