### PR TITLE
Deep nested hashes not working with has_many relationships

### DIFF
--- a/lib/flexirest/result_iterator.rb
+++ b/lib/flexirest/result_iterator.rb
@@ -45,9 +45,9 @@ module Flexirest
       @items[key]
     end
 
-    # def []=(key, value)
-    #   @items[key] = value
-    # end
+    def []=(key, value)
+      @items[key] = value
+    end
 
     def shuffle
       @items = @items.shuffle

--- a/lib/flexirest/result_iterator.rb
+++ b/lib/flexirest/result_iterator.rb
@@ -45,6 +45,10 @@ module Flexirest
       @items[key]
     end
 
+    # def []=(key, value)
+    #   @items[key] = value
+    # end
+
     def shuffle
       @items = @items.shuffle
       self

--- a/spec/lib/associations_spec.rb
+++ b/spec/lib/associations_spec.rb
@@ -16,6 +16,19 @@ class AssociationExampleBase < Flexirest::Base
   has_one :association_example_other
 end
 
+class DeepNestedHasManyChildExample < Flexirest::Base
+end
+
+class DeepNestedHasManyTopExample < Flexirest::Base
+  has_many :deep_nested_has_many_child_examples
+end
+
+class DeepNestedHasManyExample < Flexirest::Base
+  has_many :deep_nested_has_many_top_examples
+  hash = { results: [ { entries: [ { items: [ "item one", "item two" ] } ] }, { entries: [ { items: [ "item three", "item four" ] } ] } ] }
+  get :find, "/iterate", fake: hash.to_json
+end
+
 describe "Has Many Associations" do
   let(:subject) {AssociationExampleBase.new}
 
@@ -53,6 +66,11 @@ describe "Has Many Associations" do
   it "should return correctly instantiated nested associations" do
     subject.others = [{nested: [{test: "foo"}]}]
     expect(subject.others.first.nested.first.test).to eq("foo")
+  end
+
+  it "should correctly work with deep nested associations" do
+    finder = DeepNestedHasManyExample.find
+    expect(finder.results.count).to eq(2)
   end
 end
 

--- a/spec/lib/associations_spec.rb
+++ b/spec/lib/associations_spec.rb
@@ -20,11 +20,11 @@ class DeepNestedHasManyChildExample < Flexirest::Base
 end
 
 class DeepNestedHasManyTopExample < Flexirest::Base
-  has_many :deep_nested_has_many_child_examples
+  has_many :entries, DeepNestedHasManyChildExample
 end
 
 class DeepNestedHasManyExample < Flexirest::Base
-  has_many :deep_nested_has_many_top_examples
+  has_many :results, DeepNestedHasManyTopExample
   hash = { results: [ { entries: [ { items: [ "item one", "item two" ] } ] }, { entries: [ { items: [ "item three", "item four" ] } ] } ] }
   get :find, "/iterate", fake: hash.to_json
 end


### PR DESCRIPTION
Hey @lewispb, I tried the spec you wrote in #28 and agree it failed without the change.

I then tried to make your example fit the rest of the examples, but kept the `[]=` method commented out and the test still passes without it.

So now I'm confused why your test fails but this one doesn't.

Any ideas?