### PR TITLE
On plain request return the whole request instead of the body only

### DIFF
--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -388,7 +388,7 @@ module Flexirest
 
       if (200..399).include?(status)
         if @method[:options][:plain]
-          return @response = response.body
+          return @response = response
         elsif is_json_response? || is_xml_response?
           if @response.respond_to?(:proxied) && @response.proxied
             Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Response was proxied, unable to determine size"

--- a/lib/flexirest/request.rb
+++ b/lib/flexirest/request.rb
@@ -388,7 +388,10 @@ module Flexirest
 
       if (200..399).include?(status)
         if @method[:options][:plain]
-          return @response = response
+          @response.status  = response.status
+          @response.headers = response.headers
+          @response.body    = response.body
+          return @response
         elsif is_json_response? || is_xml_response?
           if @response.respond_to?(:proxied) && @response.proxied
             Flexirest::Logger.debug "  \033[1;4;32m#{Flexirest.name}\033[0m #{@instrumentation_name} - Response was proxied, unable to determine size"

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -297,7 +297,7 @@ describe Flexirest::Base do
     it "should be able to pass the plain response from the directly called URL bypassing JSON loading" do
       response_body = "This is another non-JSON string"
       expect_any_instance_of(Flexirest::Connection).to receive(:post).with(any_args).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, response_headers:{}, body:response_body)))
-      expect(EmptyExample._plain_request("http://api.example.com/", :post, {id:1234})).to eq(response_body)
+      expect(EmptyExample._plain_request("http://api.example.com/", :post, {id:1234})).to eq(OpenStruct.new(status: 200, response_headers:{}, body: response_body, headers:nil))
     end
 
     context "Simulating Faraday connection in_parallel" do
@@ -312,7 +312,7 @@ describe Flexirest::Base do
         expect(result).to eq(nil)
 
         response.finish
-        expect(result).to eq(response_body)
+        expect(result).to eq(OpenStruct.new(status: 200, response_headers:{}, body: response_body, headers:nil))
       end
     end
 
@@ -331,8 +331,8 @@ describe Flexirest::Base do
         end
         EmptyExample.perform_caching = true
         EmptyExample.cache_store = TestCacheStore.new
-        expect(EmptyExample._plain_request("http://api.example.com/?test=1")).to eq(response)
-        expect(EmptyExample._plain_request("http://api.example.com/?test=2")).to eq(other_response)
+        expect(EmptyExample._plain_request("http://api.example.com/?test=1")).to eq(OpenStruct.new(status: 200, response_headers: {}, body: response, headers: nil))
+        expect(EmptyExample._plain_request("http://api.example.com/?test=2")).to eq(OpenStruct.new(status: 200, response_headers: {}, body: other_response, headers: nil))
       ensure
         EmptyExample.perform_caching = perform_caching
         EmptyExample.cache_store = cache_store

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -264,7 +264,7 @@ describe Flexirest::Request do
   it "should not parse JSON from a plain request" do
     response_body = "This is another non-JSON string"
     expect_any_instance_of(Flexirest::Connection).to receive(:get).with(any_args).and_return(::FaradayResponseMock.new(OpenStruct.new(status:200, response_headers:{}, body:response_body)))
-    expect(ExampleClient.plain(id:1234)).to eq(response_body)
+    expect(ExampleClient.plain(id:1234)).to eq(OpenStruct.new(status: 200, response_headers:{}, body: response_body, headers:nil))
   end
 
   it "should return a lazy loader object if lazy loading is enabled" do


### PR DESCRIPTION
When you make a plain request  FlexiRest only returns the body of the request.

Many times the headers and the status of the request is useful.